### PR TITLE
Add Ruff LSP support and fix null-ls config

### DIFF
--- a/lua/plugins/configs/lspconfig.lua
+++ b/lua/plugins/configs/lspconfig.lua
@@ -64,4 +64,22 @@ require("lspconfig").lua_ls.setup {
   },
 }
 
+-- configure Ruff (Python linter) via LSP
+if require("lspconfig.configs")["ruff"] == nil then
+  require("lspconfig.configs")["ruff"] = {
+    default_config = {
+      cmd = { "ruff-lsp" },
+      filetypes = { "python" },
+      root_dir = require("lspconfig.util").find_git_ancestor,
+      settings = {},
+    },
+  }
+end
+
+require("lspconfig").ruff.setup {
+  on_init = M.on_init,
+  on_attach = M.on_attach,
+  capabilities = M.capabilities,
+}
+
 return M

--- a/lua/plugins/configs/mason.lua
+++ b/lua/plugins/configs/mason.lua
@@ -3,6 +3,7 @@ local options = {
     "lua-language-server",
     "texlab",
     "metals",
+    "ruff-lsp",
   }, -- not an option from mason.nvim
 
   PATH = "skip",

--- a/lua/plugins/configs/null_ls.lua
+++ b/lua/plugins/configs/null_ls.lua
@@ -1,0 +1,14 @@
+local null_ls = require "null-ls"
+local b = null_ls.builtins
+
+local sources = {
+  b.formatting.black,
+}
+
+if vim.fn.executable "ruff" == 1 then
+  table.insert(sources, b.diagnostics.ruff)
+end
+
+return {
+  sources = sources,
+}

--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -128,6 +128,17 @@ local default_plugins = {
     end,
   },
 
+  {
+    "nvimtools/none-ls.nvim",
+    event = { "BufReadPre", "BufNewFile" },
+    opts = function()
+      return require "plugins.configs.null_ls"
+    end,
+    config = function(_, opts)
+      require("null-ls").setup(opts)
+    end,
+  },
+
   -- load luasnips + cmp related in insert mode only
   {
     "hrsh7th/nvim-cmp",
@@ -271,4 +282,3 @@ if #config.plugins > 0 then
 end
 
 require("lazy").setup(default_plugins, config.lazy_nvim)
-


### PR DESCRIPTION
## Summary
- rename `null-ls` config file so it loads correctly
- ensure `ruff-lsp` gets installed with Mason
- configure the new `ruff` LSP server

## Testing
- `nvim --version | head -n 5`
- `nvim --headless "+qa"`


------
https://chatgpt.com/codex/tasks/task_e_687528ef993c832ab9c7fc89832cea00